### PR TITLE
Added models, API to fetch a random comic from the XKCD Server

### DIFF
--- a/sources/API.swift
+++ b/sources/API.swift
@@ -1,0 +1,46 @@
+////  API.swift
+// Created: 2019-09-20
+//
+
+
+import Foundation
+import UIKit
+
+class XkcdAPI {
+  static let endpoint = "https://xkcd.com"
+  static let endpointSuffix = "info.0.json"
+
+  static func get(comicId: Int, result: @escaping (_ xkcdComicModel: XKCDComicModel?) -> Void) {
+    var url = URL(string: endpoint)!
+    if comicId > 0 {
+      url.appendPathComponent(String(comicId))
+    }
+    url.appendPathComponent(endpointSuffix)
+    let request = URLRequest(url: url)
+
+    let task = URLSession.shared.dataTask(with: request) { data, _, error in
+      guard let data = data, error == nil else {
+        print(error?.localizedDescription ?? "No data")
+        return
+      }
+      do {
+        var xkcdComicModel = try JSONDecoder().decode(XKCDComicModel.self, from: data)
+        let imageUrl = URL(string: xkcdComicModel.imageUrl)!
+        let imageTask = URLSession.shared.dataTask(with: imageUrl) { data, _, error in
+          guard let data = data, error == nil else {
+            print(error?.localizedDescription ?? "No Image data")
+            return
+          }
+          xkcdComicModel.image = UIImage(data: data)
+          result(xkcdComicModel)
+        }
+        imageTask.resume()
+      } catch {
+        print(error)
+      }
+    }
+
+    task.resume()
+  }
+}
+

--- a/sources/ComicViewController.swift
+++ b/sources/ComicViewController.swift
@@ -22,6 +22,7 @@ class ComicViewController: UIViewController {
     return swipeGesture
   }()
 
+  let xkcdModelController = XKCDModelController()
   var historyStack = ComicStack()
   var futureStack = ComicStack()
   var currentComic: ComicModel? {
@@ -35,7 +36,10 @@ class ComicViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     setupSubViews()
-    loadFutureStack()
+    let activityIndicator = UIActivityIndicatorView(style: .gray)
+    activityIndicator.startAnimating()
+
+    populate()
     nextComic()
   }
 
@@ -70,41 +74,7 @@ class ComicViewController: UIViewController {
     view.addGestureRecognizer(forwardGestureRecognizer)
   }
 
-  private func loadFutureStack() { // HardCoded Mock Data ToDo remove and replace
-    futureStack.push(ComicModel(
-      id: 1,
-      title: "One",
-      imageURL: URL(fileURLWithPath: "www"),
-      image: UIImage(named: "Image")!)
-    )
 
-    futureStack.push(ComicModel(
-      id: 2,
-      title: "Two",
-      imageURL: URL(fileURLWithPath: "www"),
-      image: UIImage(named: "Image2")!)
-    )
-
-    futureStack.push(ComicModel(
-      id: 3,
-      title: "Three",
-      imageURL: URL(fileURLWithPath: "www"), image: UIImage(named: "Image3")!)
-    )
-
-    futureStack.push(ComicModel(
-      id: 4,
-      title: "Four",
-      imageURL: URL(fileURLWithPath: "www"),
-      image: UIImage(named: "Image4")!)
-    )
-
-    futureStack.push(ComicModel(
-      id: 5,
-      title: "Five",
-      imageURL: URL(fileURLWithPath: "www"),
-      image: UIImage(named: "Image5")!)
-    )
-  }
 
   // MARK: UTILITIES
 
@@ -146,3 +116,35 @@ class ComicViewController: UIViewController {
    */
 
 }
+
+//extension: Data Source
+extension ComicViewController: XKCDModelControllerDelegate {
+
+  private func populate() {
+    xkcdModelController.delegate = self
+    loadFutureStack()
+  }
+
+  private func loadFutureStack() {
+    // HardCoded First instance remove and replace with activity indicator
+    futureStack.push(ComicModel(
+      id: 1,
+      title: "One",
+      imageURL: URL(fileURLWithPath: "www"),
+      image: UIImage(named: "Image")!)
+    )
+    xkcdModelController.fetchRandom(count: 5, includeMostRecent: true)
+  }
+
+  func onComplete(comics: [XKCDComicModel]) {
+    _ = comics.map { futureStack.push(ComicModel(id: $0.comicId,
+                                     title: $0.title,
+                                     imageURL: URL(string: $0.imageUrl)!,
+                                     image: $0.image))
+    }
+  }
+}
+
+
+
+

--- a/sources/Models.swift
+++ b/sources/Models.swift
@@ -1,0 +1,24 @@
+////  Models.swift
+// Created: 2019-09-04
+//
+
+import Foundation
+import UIKit
+
+struct XKCDComicModel: Codable {
+  let comicId: Int
+  let alt: String
+  let imageUrl: String
+  let title: String
+  var image: UIImage?
+
+  enum CodingKeys: String, CodingKey {
+    case comicId = "num"
+    case alt
+    case imageUrl = "img"
+    case title
+  }
+
+}
+
+

--- a/sources/XKCDModelController.swift
+++ b/sources/XKCDModelController.swift
@@ -1,0 +1,57 @@
+////  XKCDModelController.swift
+// Created: 2019-09-20
+//
+
+
+import Foundation
+
+protocol XKCDModelControllerDelegate {
+  func onComplete(comics:[XKCDComicModel])
+}
+
+class XKCDModelController {
+
+  var delegate:XKCDModelControllerDelegate?
+
+  var maxComicId:Int?
+  var comic = [XKCDComicModel]()
+
+  func fetchComic(comicId:Int, complete: @escaping (_ xkcdComicModel: XKCDComicModel?) -> Void) {
+    XkcdAPI.get(comicId: comicId) { result in
+      complete(result)
+    }
+  }
+  private func fetchLatestComic(complete result:@escaping (_ xkcdComicModel: XKCDComicModel?) -> Void) {
+    fetchComic(comicId: 0, complete:result)
+  }
+
+  func fetchRandom(count:Int, includeMostRecent: Bool = true) {
+    //Fetch the latest comic first. The id will be the max range for randomness
+    var maxElements = count
+    guard maxElements > 0 else { return }
+    fetchLatestComic { [weak self] xkcdModel in
+      guard let xkcdModel = xkcdModel else { return }
+      self?.maxComicId = xkcdModel.comicId
+      if includeMostRecent {
+        self?.comic.append(xkcdModel)
+        maxElements -= 1
+        self?.maxComicId? -= 1
+      }
+
+      for index in 1...maxElements {
+        guard let maxComicId = self?.maxComicId,
+          let comicId = (1..<maxComicId).randomElement()
+          else { return }
+        //TODO: Handle collission - We don't wish to have duplicates
+        self?.fetchComic(comicId: comicId) { xkcdModel in
+          guard let xkcdModel = xkcdModel else { return }
+          self?.comic.append(xkcdModel)
+          if index == maxElements {
+            self?.delegate?.onComplete(comics:self!.comic)
+          }
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
Started writing these API with @amagin006 during the first meetup.
To fetch a random comic, we need to first determine which is the last one and pick up a number between this number and one.
I have loaded the image data in the model itself, this is not a good practice. We may store the image data in the model but UIImage (specific to UIKit) should probably be moved up to the presenting logic.
Finally, for a better ux, we load a hardcoded comic strip while others are being pulled from the server. Another possibility would be to show an activity indicator when the load is happening. Still better, we can implement some sort of a cache.
